### PR TITLE
refactor: migrate to module-based bootstrap

### DIFF
--- a/src/app/app-module.ts
+++ b/src/app/app-module.ts
@@ -1,27 +1,24 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
+import { RouterModule } from '@angular/router';
+import { MatGridListModule } from '@angular/material/grid-list';
 import { MatButtonModule } from '@angular/material/button';
-import { MatInputModule } from '@angular/material/input';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { App } from './app';
+import { Header } from './components/header/header';
+import { routes } from './app.routes';
 
 @NgModule({
-  declarations: [
-  ],
+  declarations: [App, Header],
   imports: [
-    App,
     BrowserModule,
     HttpClientModule,
-    FormsModule,
-    ReactiveFormsModule,
+    RouterModule.forRoot(routes),
+    MatGridListModule,
     MatButtonModule,
-    MatInputModule,
-    MatFormFieldModule, App
   ],
   providers: [],
   bootstrap: [App]
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,8 +13,8 @@ export const routes: Routes = [
   },
   {
     path: 'list-cep',
-    loadComponent: () =>
-      import('./components/list-cep/list-cep').then((m) => m.ListCep),
+    loadChildren: () =>
+      import('./components/list-cep/list-cep.module').then((m) => m.ListCepModule),
   },
   { path: '', redirectTo: 'home', pathMatch: 'full' },
   { path: '**', redirectTo: 'home' }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,13 +1,8 @@
-import { Component, signal } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
-
-import { Header } from './components/header/header';
-import { HttpClientModule } from '@angular/common/http';
-
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-root',
-  template: `<router-outlet></router-outlet>`,
-  imports: [RouterOutlet]
+  templateUrl: './app.html',
+  styleUrls: ['./app.scss'],
 })
 export class App {}

--- a/src/app/components/header/header.ts
+++ b/src/app/components/header/header.ts
@@ -1,16 +1,12 @@
 import { Component } from '@angular/core';
-import {MatGridListModule} from '@angular/material/grid-list';
-import {MatButtonModule} from '@angular/material/button';
-import { RouterModule } from '@angular/router';
 import { Router } from '@angular/router';
 
 
 
 @Component({
   selector: 'app-header',
-  imports: [MatGridListModule, MatButtonModule, RouterModule],
   templateUrl: './header.html',
-  styleUrl: './header.scss'
+  styleUrls: ['./header.scss']
 })
 
 export class Header {

--- a/src/app/components/home/home.module.ts
+++ b/src/app/components/home/home.module.ts
@@ -1,11 +1,16 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatGridListModule } from '@angular/material/grid-list';
+
 import { HomeRoutingModule } from './home-routing.module';
+import { Home } from './home';
 
 @NgModule({
+  declarations: [Home],
   imports: [
     CommonModule,
-    HomeRoutingModule
+    MatGridListModule,
+    HomeRoutingModule,
   ]
 })
 export class HomeModule {}

--- a/src/app/components/home/home.ts
+++ b/src/app/components/home/home.ts
@@ -1,12 +1,7 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import {MatGridListModule} from '@angular/material/grid-list';
-import { RouterModule } from '@angular/router';
-
 
 @Component({
   selector: 'app-home',
-  imports: [CommonModule, MatGridListModule, RouterModule],
   templateUrl: './home.html',
   styleUrls: ['./home.scss']
 })

--- a/src/app/components/list-cep/list-cep-routing.module.ts
+++ b/src/app/components/list-cep/list-cep-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { ListCep } from './list-cep';
+
+const routes: Routes = [{ path: '', component: ListCep }];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ListCepRoutingModule {}
+

--- a/src/app/components/list-cep/list-cep.module.ts
+++ b/src/app/components/list-cep/list-cep.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ListCep } from './list-cep';
+import { ListCepRoutingModule } from './list-cep-routing.module';
+
+@NgModule({
+  declarations: [ListCep],
+  imports: [CommonModule, ListCepRoutingModule],
+})
+export class ListCepModule {}
+

--- a/src/app/components/list-cep/list-cep.ts
+++ b/src/app/components/list-cep/list-cep.ts
@@ -1,11 +1,7 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-list-cep',
-  standalone: true, //
-  imports: [CommonModule, RouterModule],
   templateUrl: './list-cep.html',
   styleUrls: ['./list-cep.scss']
 })

--- a/src/app/components/search-cep/search-cep-routing.module.ts
+++ b/src/app/components/search-cep/search-cep-routing.module.ts
@@ -10,8 +10,4 @@ const routes: Routes = [
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
-export class SearchCepRoutingModule {
-  static forChild(arg0: never[]): any[] | import("@angular/core").Type<any> | import("@angular/core").ModuleWithProviders<{}> {
-    throw new Error('Method not implemented.');
-  }
-}
+export class SearchCepRoutingModule {}

--- a/src/app/components/search-cep/search-cep.module.ts
+++ b/src/app/components/search-cep/search-cep.module.ts
@@ -1,16 +1,28 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { MatGridListModule } from '@angular/material/grid-list';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+
 import { SearchCepRoutingModule } from './search-cep-routing.module';
 import { SearchCep } from './search-cep';
-import { RouterModule } from '@angular/router';
 
 @NgModule({
+  declarations: [SearchCep],
   imports: [
-    SearchCep,
-    SearchCepRoutingModule,
     CommonModule,
-    RouterModule
-  ]
- 
+    FormsModule,
+    ReactiveFormsModule,
+    RouterModule,
+    MatGridListModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    SearchCepRoutingModule,
+  ],
 })
 export class SearchCepModule {}
+

--- a/src/app/components/search-cep/search-cep.ts
+++ b/src/app/components/search-cep/search-cep.ts
@@ -1,26 +1,9 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
-import { MatGridListModule } from '@angular/material/grid-list';
-import { MatInputModule } from '@angular/material/input';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { FormControl, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import {MatButtonModule} from '@angular/material/button';
+import { FormControl, Validators } from '@angular/forms';
 
 
 @Component({
-  standalone: true,
   selector: 'app-search-cep',
-  imports: [
-    CommonModule,
-    RouterModule,
-    MatGridListModule,
-    FormsModule,
-    MatFormFieldModule,
-    MatInputModule,
-    ReactiveFormsModule,
-    MatButtonModule
-  ],
   templateUrl: './search-cep.html',
   styleUrls: ['./search-cep.scss']
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
-import { bootstrapApplication } from '@angular/platform-browser';
-import { appConfig } from './app/app.config';
-import { App } from './app/app';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app-module';
 
-bootstrapApplication(App, appConfig)
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- switch root bootstrap from standalone to AppModule
- declare components and modules for header, home, search-cep, and list-cep
- update routing to use lazy-loaded modules

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688ef579ae588321a6608ab2c9c5e510